### PR TITLE
Update Split.java

### DIFF
--- a/src/main/java/com/starshootercity/originsmobs/abilities/Split.java
+++ b/src/main/java/com/starshootercity/originsmobs/abilities/Split.java
@@ -45,6 +45,7 @@ public class Split implements VisibleAbility, Listener {
     @EventHandler
     public void onPlayerLeftClick(PlayerLeftClickEvent event) {
         AbilityRegister.runForAbility(event.getPlayer(), getKey(), () -> {
+            if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.AIR) return;
             if (Bukkit.getCurrentTick() - lastSplitTime.getOrDefault(event.getPlayer(), Bukkit.getCurrentTick() - 600) < 600) return;
             lastSplitTime.put(event.getPlayer(), Bukkit.getCurrentTick());
             ServerPlayer player = ((CraftPlayer) event.getPlayer()).getHandle();

--- a/src/main/java/com/starshootercity/originsmobs/abilities/WolfHowl.java
+++ b/src/main/java/com/starshootercity/originsmobs/abilities/WolfHowl.java
@@ -37,6 +37,7 @@ public class WolfHowl implements VisibleAbility, Listener {
     @EventHandler
     public void onPlayerLeftClick(PlayerLeftClickEvent event) {
         AbilityRegister.runForAbility(event.getPlayer(), getKey(), () -> {
+            if (event.getPlayer().getInventory().getItemInMainHand().getType() != Material.AIR) return;
             event.getPlayer().getWorld().playSound(event.getPlayer(), Sound.ENTITY_WOLF_HOWL, SoundCategory.PLAYERS, 1, 0.5f);
             for (Entity entity : event.getPlayer().getNearbyEntities(5, 5, 5)) {
                 if (entity instanceof LivingEntity livingEntity) {


### PR DESCRIPTION
adds a check for slimes so they have to be holding nothing in order to split. without it slimes will die constantly just by doing things like breaking blocks.